### PR TITLE
Specify stp version and docs and Makefile improvement.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,7 @@ Z3_2_19_ARCHIVE=z3-2.19.tar.gz
 KLEE_UCLIBC_URL=https://github.com/klee/klee-uclibc.git
 BEAR_URL=https://github.com/rizsotto/Bear.git
 BEAR_VERSION=2.1.4
+STP_VERSION=2.1.2
 MAXSMT_URL=https://github.com/mechtaev/maxsmt-playground.git
 LOCAL_LIB_URL=http://search.cpan.org/CPAN/authors/id/H/HA/HAARG/local-lib-2.000018.tar.gz
 LOCAL_LIB_ARCHIVE=local-lib-2.000018.tar.gz
@@ -97,7 +98,7 @@ stp: $(STP_DIR)
 	cd $(STP_DIR) && mkdir -p build && cd build && cmake -DMINISAT_LIBRARY="$(MINISAT_DIR)/build/libminisat.so.2" -DMINISAT_INCLUDE_DIR="$(MINISAT_DIR)" -G 'Unix Makefiles' $(STP_DIR) && make
 
 $(STP_DIR):
-	cd build && git clone --depth=1 $(STP_URL)
+	cd build && git clone --branch $(STP_VERSION) $(STP_URL)
 
 clean-stp:
 	rm -rf $(STP_DIR)/build

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,6 @@ CLANG_ARCHIVE=cfe-3.7.0.src.tar.xz
 CLANG_TOOLS_EXTRA_URL=http://llvm.org/git/clang-tools-extra.git
 COMPILER_RT_URL=http://llvm.org/releases/3.7.0/compiler-rt-3.7.0.src.tar.xz
 COMPILER_RT_ARCHIVE=compiler-rt-3.7.0.src.tar.xz
-CLANG_TOOLS_EXTRA_URL=http://llvm.org/git/clang-tools-extra.git
 STP_URL=https://github.com/stp/stp.git
 MINISAT_URL=https://github.com/niklasso/minisat.git
 Z3_URL=https://github.com/mechtaev/z3.git
@@ -80,7 +79,7 @@ clean-llvm-gcc:
 
 llvm2: build/$(LLVM2_ARCHIVE) build/$(LLVM2_PATCH)
 	cd build && tar xf $(LLVM2_ARCHIVE)
-	cd build && patch -p0 < $(LLVM2_PATCH)
+	cd build && patch -p0 -N < $(LLVM2_PATCH)
 	cd $(LLVM2_DIR) && ./configure --enable-optimized --enable-assertions && make
 
 build/$(LLVM2_ARCHIVE):
@@ -248,7 +247,7 @@ clang: build/$(LLVM3_ARCHIVE) build/$(CLANG_ARCHIVE) build/$(COMPILER_RT_ARCHIVE
 	cd build && tar xf $(CLANG_ARCHIVE) --directory "$(LLVM3_DIR)/tools/clang" --strip-components=1
 	mkdir -p "$(LLVM3_DIR)/projects/compiler-rt"
 	cd build && tar xf $(COMPILER_RT_ARCHIVE) --directory "$(LLVM3_DIR)/projects/compiler-rt" --strip-components=1
-	cd "$(LLVM3_DIR)/tools/clang/tools/" && git clone --branch release_37 $(CLANG_TOOLS_EXTRA_URL) extra
+	cd "$(LLVM3_DIR)/tools/clang/tools/" && rm extra -rf && git clone --branch release_37 $(CLANG_TOOLS_EXTRA_URL) extra
 	mkdir -p "$(LLVM3_DIR)/build" && cd "$(LLVM3_DIR)/build" && cmake -G "Unix Makefiles" ../ && make
 
 build/$(LLVM3_ARCHIVE):

--- a/doc/Troubleshooting.md
+++ b/doc/Troubleshooting.md
@@ -42,7 +42,7 @@ Can happen when the synthesizer is not built successfully. Try `make synthesis` 
 
 ### ANGELIX_RUN is not executed by test ... ###
 
-The test script is not instrumented correctly. Add ANGELIX_RUN according to the manual.
+The test script is not instrumented correctly. Add ANGELIX_RUN and change `oracle` file mode to `execute` according to the manual.
 
 ### ANGELIX_RUN is executed multiple times by test ... ###
 

--- a/doc/Tutorial.md
+++ b/doc/Tutorial.md
@@ -66,7 +66,7 @@ To abstract over the testing framework, Angelix utilizes three entities:
 
 This is similar to the organization of xUnit tests and can be injected into existing test framework without significant modifications.
 
-Output values are specified by wrapping them with `ANGELIX_OUTPUT` macro. In out example, the only output value is the computed distance, therefore the instrumentation will look as follows:
+Output values are specified by wrapping them with `ANGELIX_OUTPUT` macro. In out example, the only output value is the computed distance, therefore the instrumentation will look as follows (override original distance.c):
 
 ```c
 #include <stdio.h>
@@ -104,7 +104,7 @@ int main(int argc, char *argv[]) {
 
 Note that we need to provide a default definition of the `ANGELIC_OUTPUT` macro, so that the program remains compilable.
 
-Oracle script must execute the test using `ANGELIX_RUN` command if it is defined. It can be organized, for example, in the following way:
+Oracle script must execute the test using `ANGELIX_RUN` command if it is defined. It can be organized, for example, in the following way (save as `oracle`):
 
 ```shell
 #!/bin/bash
@@ -125,6 +125,8 @@ case "$1" in
         ;;
 esac
 ```
+
+And since we need to execute this file latter, please change the mode of it by `chmod +x oracle`.
 
 Apart from that, it is required to provide expected output values for failing test, because in general they cannot be extracted automatically from the test scripts. Expected output are specified using JSON format. In the example, we only need to specify the expected output for the test 3 (assert.json):
 


### PR DESCRIPTION
I think the version of stp should not be the master branch, which need `CMake 3.0.2 or higher is required.` by default and the branch `2.1.2` (Oct 2015) is also used by the [official klee document](http://klee.github.io/build-stp/).

And make the `oracle` file executable is a relief at least for me.