### PR TITLE
Made Dockerfile work

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 FROM ubuntu:14.04
 
-
 MAINTAINER Sergey Mechtaev <mechtaev@gmail.com>
 
 # Dependencies
@@ -16,18 +15,52 @@ RUN apt-get -y update
 RUN apt-get -y install git wget xz-utils build-essential \
                        curl dejagnu subversion bison flex bc libcap-dev \
                        cmake libncurses5-dev libboost-all-dev \
-                       default-jdk sbt
+                       default-jdk sbt --no-install-recommends
 
 
 # Installing Angelix
 
-RUN git clone --recursive https://github.com/mechtaev/angelix.git
+RUN apt-get install software-properties-common -y --no-install-recommends
+
+RUN git clone --recursive https://github.com/mechtaev/angelix.git --depth 1
+
+
+RUN apt-get purge icedtea-* openjdk-* -y
+RUN sudo add-apt-repository -y ppa:openjdk-r/ppa; sudo apt-get update; sudo apt-get install -y openjdk-8-jdk
+#check if java command is pointing to " link currently points to /opt/jdk/jdk1.8.0_05/bin/java"
+RUN update-alternatives --display java
+
+#check if java command is pointing to " link currently points to /opt/jdk/jdk1.8.0_05/bin/javac"
+RUN update-alternatives --display javac
+
+
+RUN java -version
+RUN javac -version
 
 WORKDIR angelix
 
 ENV JAVA_TOOL_OPTIONS -Dfile.encoding=UTF8
-
-RUN bash -c 'source activate && make z3 && make maxsmt && make synthesis && make all'
+RUN bash -c 'source activate && make -j8 llvm-gcc'
+RUN bash -c 'source activate && make -j8 llvm2'
+RUN bash -c 'source activate && make -j8 minisat'
+RUN bash -c 'source activate && make -j8 stp'
+RUN bash -c 'source activate && make -j8 klee-uclibc'
+RUN bash -c 'source activate && make -j8 klee'
+RUN bash -c 'source activate && make -j8 z3'
+RUN bash -c 'source activate && make -j8 clang'
+RUN bash -c 'source activate && make -j8 bear'
+RUN bash -c 'source activate && make -j8 runtime'
+RUN bash -c 'source activate && make -j8 frontend'
+RUN bash -c 'source activate && make -j8 maxsmt'
+RUN bash -c 'source activate && make -j8 synthesis'
+ENV VER=3.6.3
+RUN wget http://www-eu.apache.org/dist/maven/maven-3/${VER}/binaries/apache-maven-${VER}-bin.tar.gz
+RUN bash -c 'tar xvf apache-maven-${VER}-bin.tar.gz'
+RUN bash -c 'rm apache-maven-${VER}-bin.tar.gz'
+RUN bash -c 'mv apache-maven-${VER} /opt/maven'
+RUN bash -c 'echo "export MAVEN_HOME=/opt/maven;export PATH=\$MAVEN_HOME/bin:\$PATH:\$MAVEN_HOME/bin" > /etc/profile.d/maven.sh'
+RUN bash -c 'source /etc/profile.d/maven.sh && mvn -version'
+RUN bash -c 'source activate && source /etc/profile.d/maven.sh && make -j8 nsynth'
+RUN bash -c 'source activate && source /etc/profile.d/maven.sh && make -j8 semfix'
 
 RUN rm -rf build/llvm-3.7.0.src
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get -y update
 RUN apt-get -y install git wget xz-utils build-essential \
                        curl dejagnu subversion bison flex bc libcap-dev \
                        cmake libncurses5-dev libboost-all-dev \
-                       default-jdk sbt --no-install-recommends
+                       sbt --no-install-recommends
 
 
 # Installing Angelix

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN git clone --recursive https://github.com/mechtaev/angelix.git --depth 1
 
 
 RUN apt-get purge icedtea-* openjdk-* -y
-RUN sudo add-apt-repository -y ppa:openjdk-r/ppa && sudo apt-get update && sudo apt-get install -y openjdk-8-jdk
+RUN add-apt-repository -y ppa:openjdk-r/ppa && apt-get update && sudo apt-get install -y openjdk-8-jdk
 #check if java command is pointing to " link currently points to /opt/jdk/jdk1.8.0_05/bin/java"
 RUN update-alternatives --display java
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN git clone --recursive https://github.com/mechtaev/angelix.git --depth 1
 
 
 RUN apt-get purge icedtea-* openjdk-* -y
-RUN sudo add-apt-repository -y ppa:openjdk-r/ppa; sudo apt-get update; sudo apt-get install -y openjdk-8-jdk
+RUN sudo add-apt-repository -y ppa:openjdk-r/ppa && sudo apt-get update && sudo apt-get install -y openjdk-8-jdk
 #check if java command is pointing to " link currently points to /opt/jdk/jdk1.8.0_05/bin/java"
 RUN update-alternatives --display java
 


### PR DESCRIPTION
Required installing jdk-8 from a ppa, installing a more recent version of maven to handle https only on central repo. Split up build targets in makefile to make it easier to fix a broken dockerfile.